### PR TITLE
Added FOREGROUND_SERVICE permission.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.codingwithmitch.audiostreamer">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:name=".MyApplication"


### PR DESCRIPTION
From Android 9+ Apps wanting to use foreground services must request the FOREGROUND_SERVICE permission.